### PR TITLE
2.12.0 cpu (aarch64) and cpu (x86) release notes

### DIFF
--- a/2.12.0/done/result_cpu (aarch64).md
+++ b/2.12.0/done/result_cpu (aarch64).md
@@ -1,5 +1,5 @@
 
-# Release Notes worksheet cpu (x86)
+# Release Notes worksheet cpu (aarch64)
 
 You should:
 
@@ -43,16 +43,16 @@ Once you are finished, move this very file from `todo/` to `done/` and submit a 
 
 Feel free to use https://github.com/pytorch/pytorch/releases/tag/v2.10.0 as an example.
 
-## cpu (x86)
+## cpu (aarch64)
 ### bc breaking
 ### deprecation
 ### new features
 ### improvements
 ### bug fixes
+- Add vectorized BF16 `transpose_mxn` specialization for AArch64 SVE, providing a deterministic vectorized BF16 transpose implementation independent of fixed vector widths ([#174097](https://github.com/pytorch/pytorch/pull/174097))
 ### performance
 ### docs
 ### devs
 ### Untopiced
-- [CPUBlas] add brgemm API for fp8 GEMM ([#172548](https://github.com/pytorch/pytorch/pull/172548))
 ### not user facing
 ### security

--- a/2.12.0/done/result_cpu (x86).md
+++ b/2.12.0/done/result_cpu (x86).md
@@ -1,5 +1,5 @@
 
-# Release Notes worksheet cpu (aarch64)
+# Release Notes worksheet cpu (x86)
 
 You should:
 
@@ -43,13 +43,13 @@ Once you are finished, move this very file from `todo/` to `done/` and submit a 
 
 Feel free to use https://github.com/pytorch/pytorch/releases/tag/v2.10.0 as an example.
 
-## cpu (aarch64)
+## cpu (x86)
 ### bc breaking
 ### deprecation
 ### new features
+- Expose a `CPUBlas` brgemm API for fp8 (e4m3 & e5m2) GEMM, backed by oneDNN ([#172548](https://github.com/pytorch/pytorch/pull/172548))
 ### improvements
 ### bug fixes
-- [AArch64][SVE][BF16]: Add vectorized BF16 transpose_mxn specialization ([#174097](https://github.com/pytorch/pytorch/pull/174097))
 ### performance
 ### docs
 ### devs


### PR DESCRIPTION
## Summary
- Categorize and write up `result_cpu (aarch64).md` and `result_cpu (x86).md` for 2.12.0
- Move both worksheets from `todo/` to `done/`

## Test plan
- [ ] Verify entries match the linked PRs