### PR TITLE
Refresh release-blog and feature-reminder skills against the 2.13 blog format

### DIFF
--- a/.claude/skills/feature-submission-reminder/SKILL.md
+++ b/.claude/skills/feature-submission-reminder/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: feature-submission-reminder
-description: Draft a dev-discuss.pytorch.org forum post that calls for feature submissions for an upcoming PyTorch release, in the style of "Reminder — Calls for Features & Upcoming Branch Cut". Use when the user asks for a release announcement, feature-submission reminder, call-for-features post, or dev-discuss post for a release. Produces a Markdown draft that merges the official key-dates timeline with the AI-identified feature list, and asks owning teams to file "Release highlight for Proposed Feature" issues.
+description: Draft a dev-discuss.pytorch.org forum post that calls for feature submissions for an upcoming PyTorch release, in the style of "Reminder — Call for Features". Use when the user asks for a release announcement, feature-submission reminder, call-for-features post, or dev-discuss post for a release. Produces a Markdown draft that merges the official key-dates timeline with the AI-identified feature list, and asks owning teams to file "Release highlight for Proposed Feature" issues.
 disable-model-invocation: true
 ---
 
 # Feature Submission Reminder Skill
 
 Draft a dev-discuss.pytorch.org forum post in the
-"Reminder — Calls for Features" style for an upcoming (or in-flight)
+"Reminder — Call for Features" style for an upcoming (or in-flight)
 PyTorch release. The post combines:
 
 1. A call to feature owners to file release-highlight issues.
@@ -16,8 +16,12 @@ PyTorch release. The post combines:
 3. The official release timeline (M1-M6) from the dev-discuss
    key-dates post.
 
-Reference exemplar:
-<https://dev-discuss.pytorch.org/t/reminder-calls-for-features-upcoming-branch-cut/3225>
+Reference exemplars, most recent first:
+- <https://dev-discuss.pytorch.org/t/reminder-call-for-features-pytorch-2-13/3405>
+- <https://dev-discuss.pytorch.org/t/reminder-calls-for-features-upcoming-branch-cut/3225>
+
+Fetch the most recent one and match its title and section wording; the
+format drifts between releases.
 
 ## Usage
 
@@ -26,7 +30,7 @@ Reference exemplar:
 ```
 
 Defaults:
-- `<version>`: the upcoming release (e.g. `2.12`). Required.
+- `<version>`: the upcoming release (e.g. `2.14`). Required.
 
 Optional inputs the user may provide:
 - **Key-dates URL** — a link to the release's `pytorch-release-<v>-key-dates`
@@ -35,6 +39,26 @@ Optional inputs the user may provide:
   the conversation, or `auto` to call the `release-blog-features`
   skill against `release/<prev>` → `release/<version>`.
 
+## Output format: paste-ready for Discourse
+
+The release manager pastes this into the dev-discuss composer by hand.
+The skill does not post it, so the draft must survive a copy-paste.
+
+- **Put the title outside the body.** Discourse takes the title in its
+  own field, so a `#` H1 at the top of the body renders as a duplicate
+  heading. Emit the title on a labelled line at the top of the file,
+  then a `----` separator, then the body.
+- **Keep links inline** as `[text](url)`. A bare URL on its own line
+  becomes an onebox preview card in Discourse, which is not wanted
+  mid-paragraph.
+- **Wrap identifiers containing underscores in backticks.** Discourse
+  treats `_word_` as italics, so `_set_pg_timeout` renders wrong
+  unbackticked.
+- **Avoid bare `@handle`.** Discourse turns it into a user mention.
+  Backtick it or use the person's name.
+- Standard Discourse markdown is otherwise fine: `##` headings, `-`
+  bullets, `**bold**`, numbered lists, `>` blockquotes, tables.
+
 ## Workflow
 
 ### Step 1 — Gather timeline
@@ -42,19 +66,27 @@ Optional inputs the user may provide:
 If the user provided a key-dates URL, fetch it with `WebFetch` and
 extract the milestone rows verbatim — do **not** paraphrase dates.
 
-The milestones typically follow this schema (from the 2.12 key-dates
-post); confirm against the source before committing:
+The milestones typically follow this schema; confirm against the source
+before committing:
 
 - **M1** — Release announcement
 - **M2** — All PRs landed / Feature submission closed
-- **M3.1** — Release branch cut
+- **M3** — Release branch cut, RC1 for PyTorch and Torchvision
 - **M4** — Release branch finalized, final RC, feature classifications
 - **M4.1** — Tutorial drafts submission deadline
 - **M5** — External-facing content finalized
 - **M6** — Release Day
 
 Mark any milestone whose date is in the past as `**Done**` alongside
-the date. Do not invent M3.2/M3.3 rows if they aren't in the source.
+the date. Do not invent M3.1/M3.2 rows if they aren't in the source.
+
+**Say where the release currently stands.** In practice this post goes
+out *after* the branch cut: the 2.13 reminder was posted 24 June, with
+M3 in the week of 8 June and M4 in the week of 22 June. A call for
+features that lands after M2 reads as already-too-late unless the post
+says otherwise. Fill `{{MILESTONE_STATUS_NOTE}}` with which milestones
+are complete and note that feature classifications are published at M4,
+so issues filed now can still make the blog.
 
 ### Step 2 — Gather feature list
 
@@ -62,47 +94,56 @@ Priority order:
 
 1. If the user supplied a feature list inline or at a file path, use
    that directly.
-2. If there is a recent `<version>/blog-draft.md` in this repo (from
-   `release-blog-features`), reuse its **major features** section.
+2. If there is a recent `<X.Y.Z>/blog-draft.md` in this repo (from
+   `release-blog-features`), reuse its feature sections.
 3. Otherwise, invoke the `release-blog-features` skill against
    `release/<prev>` → `release/<version>` and use its output.
 
 Apply the "major features only" filter (≥4 PRs each) unless the user
 asks for the long list.
 
-### Step 3 — Draft the post
+Group the list the way the blog does — Features, Performance
+Improvements, Deprecations and BC-breaking changes, Non-Feature Updates
+— so the two documents agree.
+
+### Step 3 — Identify the under-sampled areas
+
+The post asks readers to fill gaps, so name the areas most likely to
+have them. **Derive this from the worksheet counts rather than reusing
+last release's list**, which changes every cycle. Count candidate
+entries per area in `<X.Y.Z>/todo/` and `<X.Y.Z>/done/` and name the
+thinnest user-facing areas in `{{UNDER_SAMPLED_AREAS}}`.
+
+For 2.14 the thin areas were Quantization (13 candidates, nearly all
+typo fixes), ONNX (5), Export (9) and CPU x86/aarch64 (3 and 2), while
+MPS was the single largest pool at 82 — the opposite of the standing
+assumption that MPS is under-sampled.
+
+### Step 4 — Draft the post
 
 Use [announcement-template.md](announcement-template.md) as the
 starting point. Substitute:
 
-- `{{VERSION}}` — release version (e.g., `2.12`)
+- `{{VERSION}}` — release version (e.g., `2.14`)
+- `{{PREV_VERSION}}` — previous release (e.g., `2.13`)
 - `{{FEATURES_MARKDOWN}}` — the grouped feature list
-- `{{TIMELINE_TABLE}}` — the M1-M6 table with dates from Step 1
-- `{{KEY_DATES_URL}}` — link back to the source key-dates post
+- `{{TIMELINE_TABLE}}` — the M1-M6 rows with dates from Step 1
+- `{{MILESTONE_STATUS_NOTE}}` — which milestones are done (Step 1)
+- `{{UNDER_SAMPLED_AREAS}}` — the thin areas (Step 3)
 
 Always include:
 
-- The AI-identified label on the feature section (e.g.,
-  "Features Identified by AI") and a note that the list is not
-  authoritative.
+- The AI-identified label on the feature section and a note that the
+  list is not authoritative.
 - A blockquoted ask: *"If your team is responsible for one of the
   features below, please submit a Release highlight for Proposed
   Feature issue."*
-- An explicit call for missing features (especially in areas where
-  AI scans typically under-sample — MPS, Quantization, CPU/Arm).
+- An explicit call for missing features.
 
-### Step 4 — Save and (optionally) publish
+### Step 5 — Save
 
-Save the draft to `<version>/feature-submission-reminder.md` in this
-repo.
-
-If the user asks for a Google Doc version, use the `google-docs`
-skill:
-
-```
-gdocs create "PyTorch <version> Release — Call for Features" \
-    --from <version>/feature-submission-reminder.md
-```
+Save the draft to `<X.Y.Z>/feature-submission-reminder.md` in this
+repo. Note the directory is the full `X.Y.Z` version, e.g. `2.14.0/`.
 
 Do **not** post to dev-discuss directly — the release manager will
 review the draft and post it.
@@ -111,22 +152,32 @@ review the draft and post it.
 
 Every draft must contain:
 
-1. **Title line** in the format `Reminder — Calls for Features & Upcoming Branch Cut: PyTorch <version>`.
+1. **Title line** outside the body, in the format used by the most
+   recent post (2.13 used `Reminder — Call for Features: PyTorch <version>`;
+   earlier posts used `Reminder — Calls for Features & Upcoming Branch Cut`).
 2. **How to submit** section listing the two canonical mechanisms
-   (new issue via template, or tag an existing RFC with
+   (new issue via template, or label an existing RFC with
    `release-feature-request`).
 3. **Checklist of what to include** in each feature submission:
-   availability in the release, API stability tag, tutorial links,
-   blog blurb, platform caveats.
+   what ships in the release, the stability designation, tutorial
+   links, blog blurb, platform caveats.
 4. **Feature list** with clear "AI-identified, not authoritative"
    framing.
-5. **Timeline table** with exact dates from the key-dates post.
+5. **Timeline table** with exact dates from the key-dates post, plus a
+   note on which milestones are complete.
 6. **Closing sign-off**: `Cheers,` / `Team PyTorch`.
+
+## Designations
+
+Ask for **API Stable** or **API Unstable**. Beta and Prototype are
+retired — the 2.13 release blog carries an explicit changelog note
+that prototype "is a designation that we no longer use." Do not ask
+feature owners for a Stable/Beta/Prototype tag.
 
 ## Things to avoid
 
 - **Don't invent milestones or dates.** If the key-dates post doesn't
-  list M3.2/M3.3, don't add them. If a date is missing, mark it
+  list a milestone, don't add it. If a date is missing, mark it
   `TODO(release-manager)`.
 - **Don't claim authority.** Every feature description should be
   framed as an AI-generated starting point, not a team-confirmed
@@ -134,4 +185,6 @@ Every draft must contain:
 - **Don't include PR numbers in the feature list.** The reminder post
   is a call-to-action for teams, not a release-notes dump. Keep it
   readable.
+- **Don't reuse last release's list of under-sampled areas.** Recount
+  from the worksheets.
 - **Don't publish.** This skill drafts posts; it never posts them.

--- a/.claude/skills/feature-submission-reminder/SKILL.md
+++ b/.claude/skills/feature-submission-reminder/SKILL.md
@@ -51,13 +51,22 @@ The skill does not post it, so the draft must survive a copy-paste.
 - **Keep links inline** as `[text](url)`. A bare URL on its own line
   becomes an onebox preview card in Discourse, which is not wanted
   mid-paragraph.
+- **Avoid `**bold**` emphasis, and tell the user to paste as plain
+  text.** Discourse converts pasted *HTML* to Markdown, and most
+  sources put HTML on the clipboard: copying from a syntax-highlighting
+  editor or a rendered file view yields `<strong>**IMPORTANT**</strong>`,
+  which Discourse turns into `**\*\*IMPORTANT\*\***`. Plain-text paste
+  (Cmd+Shift+V / Ctrl+Shift+V) avoids it, but emphasis markers are the
+  first thing to break if the user forgets, so prefer plain wording and
+  lean on headings and lists for structure. Put the plain-text-paste
+  instruction in the file itself, above the separator.
 - **Wrap identifiers containing underscores in backticks.** Discourse
   treats `_word_` as italics, so `_set_pg_timeout` renders wrong
   unbackticked.
 - **Avoid bare `@handle`.** Discourse turns it into a user mention.
   Backtick it or use the person's name.
 - Standard Discourse markdown is otherwise fine: `##` headings, `-`
-  bullets, `**bold**`, numbered lists, `>` blockquotes, tables.
+  bullets, numbered lists, `>` blockquotes, tables.
 
 ## Workflow
 

--- a/.claude/skills/feature-submission-reminder/announcement-template.md
+++ b/.claude/skills/feature-submission-reminder/announcement-template.md
@@ -1,37 +1,37 @@
 Title (paste into the title field): Reminder — Call for Features: PyTorch {{VERSION}}
 Category: Release Announcements
 
-Paste everything below this line into the composer body.
+Paste everything below this line into the composer body, using plain-text paste (Cmd+Shift+V / Ctrl+Shift+V).
 
 ----
 
 Hi everyone,
 
-This is a reminder to feature owners to **file a release-highlight issue** for every feature you want tracked in the {{VERSION}} release.
+This is a reminder to feature owners to file a release-highlight issue for every feature you want tracked in the {{VERSION}} release.
 
-**IMPORTANT**: features that are not submitted will NOT be mentioned in the release blog or other comms.
+IMPORTANT: features that are not submitted will NOT be mentioned in the release blog or other comms.
 
 ## How to submit
 
 Either one of:
 
-1. **Open a new issue** on pytorch/pytorch using the **"Release highlight for Proposed Feature"** template, or
+1. Open a new issue on pytorch/pytorch using the "Release highlight for Proposed Feature" template, or
 2. Label an existing RFC or tracking issue with `release-feature-request`.
 
 Please include, per feature:
 
-- **What ships in {{VERSION}}** — the API surface, plus a stability designation: **API Stable** or **API Unstable**. (Beta and Prototype are no longer used as designations.)
-- **Tutorial links**, new or updated.
-- **A short blog-post write-up** (2-3 paragraphs, usable as-is in the release blog).
-- **Platform/backend caveats** — CUDA / ROCm / XPU / MPS / CPU-Arm.
+- What ships in {{VERSION}}: the API surface, plus a stability designation of either API Stable or API Unstable. (Beta and Prototype are no longer used as designations.)
+- Tutorial links, new or updated.
+- A short blog-post write-up, 2-3 paragraphs, usable as-is in the release blog.
+- Any platform or backend caveats: CUDA, ROCm, XPU, MPS, CPU-Arm.
 
 The running list of tracked features lives [here](https://github.com/pytorch/pytorch/issues?q=label%3Arelease-feature-request+is%3Aissue).
 
 ## {{VERSION}} Features Identified by AI
 
-The following was identified by an AI-assisted scan of the `release/{{PREV_VERSION}}` to `release/{{VERSION}}` diff. **This list is a starting point, not authoritative** — descriptions and designations have not been reviewed by the feature owners, so it will miss things and mis-scope others.
+The following was identified by an AI-assisted scan of the `release/{{PREV_VERSION}}` to `release/{{VERSION}}` diff. This list is a starting point, not authoritative: descriptions and designations have not been reviewed by the feature owners, so it will miss things and mis-scope others.
 
-> **Note:** If your team is responsible for one of the features below, please submit a **"Release highlight for Proposed Feature"** issue so we can track the official description, tutorial, and blog write-up. Corrections and missing features are equally welcome — reply on this thread or open an issue.
+> Note: if your team is responsible for one of the features below, please submit a "Release highlight for Proposed Feature" issue so we can track the official description, tutorial, and blog write-up. Corrections and missing features are equally welcome — reply on this thread or open an issue.
 
 {{FEATURES_MARKDOWN}}
 
@@ -43,9 +43,9 @@ The following was identified by an AI-assisted scan of the `release/{{PREV_VERSI
 
 ## How you can help
 
-- **Feature owners**: submit a release-highlight issue with the blog blurb and tutorial links.
-- **Tutorial authors**: open PRs against pytorch/tutorials tagged `{{VERSION}}-release`. These are tracked toward M4.1.
-- **Everyone else**: flag anything major that is missing from the list above, particularly in {{UNDER_SAMPLED_AREAS}}.
+- Feature owners: submit a release-highlight issue with the blog blurb and tutorial links.
+- Tutorial authors: open PRs against pytorch/tutorials tagged `{{VERSION}}-release`. These are tracked toward M4.1.
+- Everyone else: flag anything major that is missing from the list above, particularly in {{UNDER_SAMPLED_AREAS}}.
 
 Questions welcome on this thread.
 

--- a/.claude/skills/feature-submission-reminder/announcement-template.md
+++ b/.claude/skills/feature-submission-reminder/announcement-template.md
@@ -1,67 +1,54 @@
-# Reminder — Calls for Features & Upcoming Branch Cut: PyTorch {{VERSION}}
+Title (paste into the title field): Reminder — Call for Features: PyTorch {{VERSION}}
+Category: Release Announcements
+
+Paste everything below this line into the composer body.
+
+----
 
 Hi everyone,
 
-As we head into the PyTorch {{VERSION}} release cycle, this is a
-reminder to feature owners to **file a release-highlight issue** for
-every feature you want tracked in the release.
+This is a reminder to feature owners to **file a release-highlight issue** for every feature you want tracked in the {{VERSION}} release.
 
-## How to submit a feature
+**IMPORTANT**: features that are not submitted will NOT be mentioned in the release blog or other comms.
 
-Please either:
+## How to submit
 
-1. **Open a new issue** on `pytorch/pytorch` using the
-   **"Release highlight for Proposed Feature"** template, **or**
-2. Tag an existing RFC / tracking issue with the
-   **`release-feature-request`** label.
+Either one of:
 
-For each feature, include:
+1. **Open a new issue** on pytorch/pytorch using the **"Release highlight for Proposed Feature"** template, or
+2. Label an existing RFC or tracking issue with `release-feature-request`.
 
-- What will be available in **release {{VERSION}}** (API surface,
-  stability tag: Stable / Beta / Prototype)
-- Link(s) to **relevant tutorials** (new or updated)
-- A short **blog-post write-up** (2-3 paragraphs, usable as-is in the
-  release blog)
-- Any platform or backend caveats (CUDA / ROCm / XPU / MPS / CPU-Arm)
+Please include, per feature:
 
-The running list of tracked features lives here:
-<https://github.com/pytorch/pytorch/issues?q=label%3Arelease-feature-request+is%3Aissue>
+- **What ships in {{VERSION}}** — the API surface, plus a stability designation: **API Stable** or **API Unstable**. (Beta and Prototype are no longer used as designations.)
+- **Tutorial links**, new or updated.
+- **A short blog-post write-up** (2-3 paragraphs, usable as-is in the release blog).
+- **Platform/backend caveats** — CUDA / ROCm / XPU / MPS / CPU-Arm.
+
+The running list of tracked features lives [here](https://github.com/pytorch/pytorch/issues?q=label%3Arelease-feature-request+is%3Aissue).
 
 ## {{VERSION}} Features Identified by AI
 
-The following major features were identified by an AI-assisted scan
-of the `release/{{PREV_VERSION}} → release/{{VERSION}}` commit diff.
-This list is a starting point, not authoritative — descriptions and
-stability tags have not been reviewed by the feature owners.
+The following was identified by an AI-assisted scan of the `release/{{PREV_VERSION}}` to `release/{{VERSION}}` diff. **This list is a starting point, not authoritative** — descriptions and designations have not been reviewed by the feature owners, so it will miss things and mis-scope others.
 
-> **Note:** If your team is responsible for one of the features
-> below, please submit a **"Release highlight for Proposed Feature"**
-> issue so we can track the official description, tutorial, and blog
-> write-up. Corrections and missing features are equally welcome —
-> reply on this thread or open an issue.
+> **Note:** If your team is responsible for one of the features below, please submit a **"Release highlight for Proposed Feature"** issue so we can track the official description, tutorial, and blog write-up. Corrections and missing features are equally welcome — reply on this thread or open an issue.
 
 {{FEATURES_MARKDOWN}}
 
 ## {{VERSION}} Release Timeline
 
-Official dates from the
-[PyTorch Release {{VERSION}} Key Dates]({{KEY_DATES_URL}}) post:
-
 {{TIMELINE_TABLE}}
 
-## How to help
+{{MILESTONE_STATUS_NOTE}}
 
-- **Feature owners:** file a release-highlight issue (template above)
-  with your blog blurb + tutorial links.
-- **Tutorial authors:** PRs to `pytorch/tutorials` with the
-  `{{VERSION}}-release` label are tracked against M4.1.
-- **Everyone else:** please review the feature list above and reply
-  in this thread if something major is **missing** — particularly
-  for MPS, Quantization, and CPU/Arm, where the diff-based scan
-  typically catches few candidates.
+## How you can help
 
-If you have questions, reach out in `#release-engineering` on Slack
-or reply on this topic.
+- **Feature owners**: submit a release-highlight issue with the blog blurb and tutorial links.
+- **Tutorial authors**: open PRs against pytorch/tutorials tagged `{{VERSION}}-release`. These are tracked toward M4.1.
+- **Everyone else**: flag anything major that is missing from the list above, particularly in {{UNDER_SAMPLED_AREAS}}.
+
+Questions welcome on this thread.
 
 Cheers,
+
 Team PyTorch

--- a/.claude/skills/release-blog-features/SKILL.md
+++ b/.claude/skills/release-blog-features/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: release-blog-features
-description: Produce a draft "Features" section for a PyTorch release blog post by comparing two release branches (e.g., release/2.11 vs release/2.12). Use when the user asks to generate a release blog, list new features for a release, compare release branches, or draft content for pytorch.org/blog. Organizes features similar to https://pytorch.org/blog/pytorch-2-11-release-blog/ with Highlights and per-component sections (Dynamo, Inductor, Distributed, Export, MPS, ROCm, XPU, CPU, etc.), each tagged with stability (Stable / Beta / Prototype / API-Unstable).
+description: Produce a draft PyTorch release blog by comparing two release branches (e.g., release/2.13 vs release/2.14). Use when the user asks to generate a release blog, list new features for a release, compare release branches, or draft content for pytorch.org/blog. Organizes features the way recent posts do (https://pytorch.org/blog/pytorch-2-13-release-blog/) — grouped by topic (Performance Improvements, Core Features, Distributed Training, Compilation and Export, Platform Features and Updates, Profiling and Debugging), with each entry carrying an "API Unstable" designation and a PR attribution.
 disable-model-invocation: true
 ---
 
 # PyTorch Release Blog Features Skill
 
-Produce a draft list of features for a PyTorch release blog post by
-diffing two release branches and organizing the noteworthy changes
-into the format used on pytorch.org/blog.
+Produce a draft release blog post by diffing two release branches and
+organizing the noteworthy changes into the format used on
+pytorch.org/blog.
 
 ## Usage
 
@@ -16,36 +16,97 @@ The user invokes the skill with two release branches (a "base" and a
 "target"), for example:
 
 ```
-Generate features for the 2.12 release blog (release/2.11 → release/2.12)
+Generate the 2.14 release blog (release/2.13 → release/2.14)
 ```
 
 Default behavior when the user only gives the target version:
-- base = `release/<previous-minor>` (e.g. `release/2.11` for target 2.12)
-- target = `release/<target>` (e.g. `release/2.12`)
+- base = `release/<previous-minor>` (e.g. `release/2.13` for target 2.14)
+- target = `release/<target>` (e.g. `release/2.14`)
 
 Always confirm the two refs you'll compare before doing any heavy work.
 
+## Read the most recent published blog first
+
+**Do this before drafting.** Fetch the previous release's blog post
+(e.g. <https://pytorch.org/blog/pytorch-2-13-release-blog/>) and match
+its structure. The format changes between releases — designations have
+been retired, sections renamed — and the published post is the only
+authoritative source for the current shape. Everything below describes
+the format as of 2.13; verify it still holds.
+
 ## What to produce
 
-A Markdown document with the same structure as recent release blogs
-(see [reference-structure.md](reference-structure.md) for a template
-and an example based on the 2.11 blog). At a high level:
+A Markdown document mirroring the previous release's blog. See
+[reference-structure.md](reference-structure.md) for the full template.
+In outline:
 
-1. **Header** — version, link to release notes, commit/contributor stats.
-2. **Highlights** — 5-10 bullet points of the most notable features.
-3. **Feature sections** — one subsection per feature, tagged with
-   `[Stable]`, `[Beta]`, `[Prototype]`, or `[API-Unstable]`, and grouped
-   by component (Dynamo, Inductor, Distributed, Export, Quantization,
-   MPS, ROCm, XPU, CPU, Arm, Release Engineering, etc.).
-4. **Deprecations / BC-breaking** — only if any are found.
-5. **Non-feature updates** — version bumps (CUDA default, Python min),
-   release-cadence changes, etc.
+1. **Header** — one-line announcement with a release-notes link, a
+   bulleted highlight list, the commit/contributor count with thanks,
+   a live Q&A paragraph, and a short narrative placing the release in
+   the 2.x arc.
+2. **Topic sections** — Performance Improvements, Core Features,
+   Distributed Training, Compilation and Export, Platform Features and
+   Updates (subsectioned per backend), Profiling and Debugging.
+3. **Deprecations and Backwards-Incompatible Changes**.
+4. **Non-Feature Updates** — version matrix, dependency bumps.
 
-Each feature entry should contain:
-- Short title and stability tag
-- 1-3 sentence description written for a blog audience (not a commit log)
-- Links to representative PRs (`#12345`) and docs where relevant
-- Platform/backend notes if applicable
+### Designations
+
+Recent blogs use exactly one designation, **API Unstable**, placed on
+its own line after an entry's prose and before the PR attribution:
+
+```markdown
+### Deterministic Backward for FlexAttention Flash Backend
+
+<two or three paragraphs>
+
+API Unstable
+
+(PR [#174813](https://github.com/pytorch/pytorch/pull/174813) by Driss Guessous, Meta)
+```
+
+**Stable, Beta and Prototype are retired.** The 2.13 post carries an
+explicit changelog note: *"Removed two instances of prototype which is
+a designation that we no longer use."* Do not reintroduce them, and do
+not put designations in headings as a `[Tag]` prefix — they are body
+text.
+
+If you cannot tell whether something is API Unstable, leave the line
+off and flag it with `TODO(release-manager):` rather than guessing.
+
+### Attribution
+
+Every entry ends with a PR attribution naming the authors and their
+affiliations: `(PR #NNNNN by Firstname Lastname, Company)`. Multiple
+PRs and authors are grouped in one line.
+
+The worksheets carry **no author metadata**, so fetch it:
+
+```bash
+# gh may not be available; the REST API works with any token
+curl -s -H "Authorization: Bearer $TOKEN" \
+  https://api.github.com/repos/pytorch/pytorch/pulls/<NUM> \
+  | jq -r '.user.login, .title'
+```
+
+That gives you handles, not real names or affiliations. Emit handles
+and leave a `TODO(release-manager)` to convert them, unless the user
+supplies a mapping — do not guess someone's employer.
+
+### Entry voice
+
+Published entries open with the *problem*, then the fix. Compare:
+
+- Bad (commit voice): "Adds a stream pool to MPS."
+- Good: "Long-running decode workloads grew the MPS caching allocator's
+  reserved footprint faster than necessary. The allocator now buckets
+  large allocations..."
+
+Two or three paragraphs per entry. Lift phrasing from the PR body's
+summary rather than re-describing the diff. Where the previous release
+introduced something this release extends, say so explicitly ("Building
+on FlexAttention's arrival on MPS in 2.13, ...") — the published blogs
+consistently thread releases together.
 
 Do **not** invent features, metrics, or API names. If something is
 ambiguous, mark it with `TODO:` so the release manager can resolve it.
@@ -63,143 +124,159 @@ git merge-base origin/release/<base> origin/release/<target>
 ```
 
 Prefer `origin/release/<x>` over bare `release/<x>` when fetching, and
-use the actual tag (e.g. `v2.11.0`) over the branch when it exists,
+use the actual tag (e.g. `v2.13.0`) over the branch when it exists,
 because the branch may contain post-release cherry-picks.
 
 ### Step 2 — Collect the commit list
 
-Two viable options — pick based on what is available:
+**Option A: reuse the worksheets in this repo (preferred).**
 
-**Option A: reuse completed worksheets in this repo (preferred).**
-
-This repo already categorizes PRs per area in
-`<version>/done/result_<area>.md` (via `gen-release-notes`). Read those
-worksheets first — they have the PRs already grouped by area and by
-topic (`### new features`, `### improvements`, etc.), which is exactly
-what the blog needs.
+This repo categorizes PRs per area in `<X.Y.Z>/done/result_<area>.md`
+and `<X.Y.Z>/todo/result_<area>.md` (via `gen-release-notes`). Note the
+directory is the full `X.Y.Z` version, e.g. `2.14.0/`, not `2.14/`.
 
 ```bash
-ls <version>/done/
-# Each result_<area>.md has PRs under ### new features, etc.
+ls <X.Y.Z>/done/ <X.Y.Z>/todo/
 ```
 
-If the version still has PRs in `<version>/todo/`, flag that to the
-user — the blog draft will be incomplete until those worksheets are
-processed.
+**Check how much triage has actually happened before trusting the
+topic headings.** A completed worksheet sorts PRs under `### new
+features`, `### improvements`, `### performance` and so on. An
+untriaged one leaves everything under `### Untopiced`. In practice the
+blog is often drafted before triage finishes — for 2.14, 46 of 47
+worksheets were still in `todo/` with 1,202 PRs under `### Untopiced`
+and only 11 sorted into `### new features`.
 
-**Option B: raw git log + gh lookup** (use when worksheets are not
+When that is the case:
+
+- Draw candidates from `### Untopiced` plus `### improvements`,
+  `### performance` and `### new features`.
+- Skip `### not user facing`, and skip `result_skip.md` and
+  `result_not needed.md` entirely.
+- **Say so in the draft.** Add a note stating which worksheets were
+  untriaged and that coverage is best-effort, so the release manager
+  knows the draft is not a complete scan.
+
+Entry format in the worksheets is one bullet per PR:
+
+```
+- <title> ([#189417](https://github.com/pytorch/pytorch/pull/189417))
+```
+
+**Option B: raw git log + PR lookup** (use when worksheets are not
 available):
 
 ```bash
-# Titles + PR numbers, one per commit (run in pytorch/pytorch checkout)
 git log --pretty=format:'%H %s' \
     origin/release/<base>..origin/release/<target> \
     > /tmp/release-commits.txt
-
-# Batch-fetch PR labels via GraphQL (gh CLI required):
-gh api graphql -f query='
-{
-  pr<NUM>: repository(owner: "pytorch", name: "pytorch") {
-    pullRequest(number: <NUM>) { number title labels(first: 10) { nodes { name } } }
-  }
-  ...
-}'
 ```
 
-GraphQL supports ~100 aliases per query, so split into multiple
-queries.
+Then batch-fetch labels via the REST or GraphQL API. GraphQL supports
+~100 aliases per query, so split into multiple queries.
 
 ### Step 3 — Filter to "blog-worthy" changes
 
-A release has thousands of commits. The blog only highlights a small
-fraction. Use these signals, in order:
+A release has thousands of commits; the blog highlights a few dozen.
+Use these signals, in order:
 
-1. **`release notes:` labels** — PRs labelled `release notes: <area>`
-   are the canonical source of user-facing changes. Prefer these.
-2. **"New feature" / "Beta" / "Prototype" labels** and wording in the
-   PR body (e.g. `## Summary` mentions a new public API).
-3. **New public APIs** — PRs that add to `torch/`, `torch/nn/`,
-   `torch/distributed/`, `torch/export/`, etc., especially new `.py`
-   modules or new entries in `__all__`.
-4. **Dashboard / perf callouts** — PRs referencing the PyTorch HUD or
-   numerical speedups.
-5. **Platform enablement** — new backends, new hardware, new wheel
-   variants (ROCm, XPU, CUDA major bump, aarch64).
+1. **`release notes:` labels** — the canonical source of user-facing
+   changes.
+2. **New public APIs** — additions to `torch/`, `torch/nn/`,
+   `torch/distributed/`, `torch/export/`, especially new modules or
+   new `__all__` entries.
+3. **Wording in the PR body** — a `## Summary` that describes a new
+   public API or a measured speedup.
+4. **Platform enablement** — new backends, new hardware, new wheel
+   variants (ROCm, XPU, CUDA major bump, aarch64, riscv64).
 
 Ignore: pure refactors, test infra, lint fixes, typo fixes, internal
 dispatcher churn, reverts, and cherry-picks that land on both branches.
 
-### Step 4 — Categorize
+Typo-fix PRs are a large share of the `Untopiced` pool and are never
+blog-worthy; filter them early.
 
-Group the survivors into components. The canonical set used by recent
-blogs (use these exact names when they apply):
+### Step 4 — Group by topic
 
-- **Dynamo / torch.compile**
-- **Inductor**
-- **Distributed** (FSDP, DTensor, DeviceMesh, symmetric memory,
-  pipelining, collectives)
-- **Export** (`torch.export`, AOTInductor)
-- **Quantization**
-- **Profiler**
-- **ONNX**
-- **NN / Frontend** (FlexAttention, SDPA, new modules)
-- **MPS** (Apple Silicon)
-- **ROCm** (AMD)
-- **XPU** (Intel)
-- **CPU / Arm**
-- **CUDA** (default version change, cuDNN, CUTLASS integrations)
-- **libtorch / C++ ABI** (`torch::stable`)
-- **Release Engineering** (wheel variants, Python/CUDA support matrix)
+Group survivors into the sections the previous blog used. As of 2.13:
 
-Tag each entry with a stability level. If the PR body explicitly says
-"prototype" or "experimental", use `[Prototype]` / `[API-Unstable]`.
-Otherwise, infer from the PR's release-notes label and from whether
-the API is gated behind a private namespace (`torch._*`).
+- **Performance Improvements** — including large backend rewrites, e.g.
+  the MPS Metal migration lived here, not under MPS.
+- **Core Features** — new ops, frontend APIs, autograd surfaces.
+- **Distributed Training** — c10d, backends, FSDP, DTensor, symmetric
+  memory, pipelining.
+- **Compilation and Export** — Dynamo, dynamic shapes, AOTInductor,
+  backend registration.
+- **Platform Features and Updates** — `### CUDA`, `### ROCm`,
+  `### Arm`, `### MPS`, `### XPU (Intel GPUs)`, `### C++ ABI`, each
+  with `####` entries.
+- **Profiling and Debugging**.
+
+A backend-specific compiler feature goes under its platform, not under
+Compilation: 2.13 filed the CuTeDSL Inductor backend under CUDA.
 
 ### Step 5 — Apply the "major feature" threshold
 
-When the user asks for **major features only**, drop any feature
-backed by 3 or fewer PRs. Smaller entries typically belong in the long
-release notes, not the blog.
+When the user asks for **major features only**, drop any feature backed
+by 3 or fewer PRs — after Step 6, so a collapsed stack counts as its
+full size. Smaller entries belong in the long release notes.
 
 ### Step 6 — Deduplicate ghstack stacks
 
-A feature often lands as 5-15 ghstack PRs. Collapse them to one blog
-entry citing the user-facing PR (usually the top of the stack, which
-adds the public API or docs).
+A feature often lands as 5-40 ghstack PRs. Collapse them to one entry
+citing the user-facing PRs. For 2.14, NVGEMM was ~35 PRs and the
+torchcomms `nccl2` backend ~40; each became a single entry with a
+handful of representative links.
 
 ### Step 7 — Draft the blog
 
 Open [reference-structure.md](reference-structure.md) and follow the
-template. Keep descriptions blog-voice, not commit-voice: write for a
-PyTorch user deciding whether to upgrade, not for a reviewer.
+template. Write for a PyTorch user deciding whether to upgrade, not for
+a reviewer.
 
 ### Step 8 — Gather stats for the header
 
 ```bash
 # In the pytorch/pytorch checkout:
-git log --no-merges --oneline \
-    origin/release/<base>..origin/release/<target> | wc -l
-git log --format='%an' \
-    origin/release/<base>..origin/release/<target> | sort -u | wc -l
+git log --no-merges --oneline v<base>.0..origin/release/<target> | wc -l
+git log --format='%an' v<base>.0..origin/release/<target> | sort -u | wc -l
 ```
+
+### Step 9 — Verify the support matrix
+
+Do not carry version numbers over from the previous blog or infer them
+from PR titles. Read them off the release branch:
+
+```bash
+git show origin/release/<target>:.github/scripts/generate_binary_build_matrix.py \
+  | grep -E '^(CUDA_ARCHES|CUDA_STABLE|ROCM_ARCHES|FULL_PYTHON_VERSIONS)'
+```
+
+Diff against the base branch's copy so you can state what was added and
+dropped. Watch for architectures that are built but deliberately not
+advertised — 2.14 built CUDA 13.4 while excluding it from Windows and
+the docker release matrix, so it was not a 2.14 install option.
 
 ## Output
 
-Save the draft to `<version>/blog-draft.md` in this repo. Do not
-commit automatically — the release manager will review and move the
-polished version into the pytorch.org blog repo.
+Save the draft to `<X.Y.Z>/blog-draft.md` in this repo. Do not commit
+automatically — the release manager will review and move the polished
+version into the pytorch.org blog repo.
 
 ## Best practices
 
+- **Read the previous blog first.** The format drifts; the published
+  post is authoritative, this skill is a summary of it.
 - **Confirm scope before you dig in.** Thousands of commits; the user
-  cares about ~10 major features.
+  cares about a few dozen entries.
 - **Let the PR author's words do the work.** Lift phrasing from the PR
-  body's "Summary" section rather than re-describing the change from
-  the diff.
-- **Flag uncertainty.** `TODO(release-manager): is this beta or
-  prototype?` is more useful than a confident guess.
+  body's summary rather than re-describing the change from the diff.
+- **Flag uncertainty.** `TODO(release-manager): is this API Unstable?`
+  is more useful than a confident guess.
 - **Don't overclaim performance.** Only cite speedups that appear in
-  the PR body or linked dashboard — never invent numbers.
+  the PR body or a linked dashboard — never invent numbers. When a
+  number comes from a PR title, attribute it that way ("the PR reports
+  recovering an 8.5x regression").
 - **Skip reverts and follow-ups.** If PR #A landed and PR #B reverted
   it before the release branch was cut, neither belongs in the blog.
+  Check reverts on the release branch too, not just on main.

--- a/.claude/skills/release-blog-features/reference-structure.md
+++ b/.claude/skills/release-blog-features/reference-structure.md
@@ -1,165 +1,212 @@
 # PyTorch Release Blog — Output Template & Examples
 
-Use this template when drafting a release blog. It mirrors the structure
-of recent posts on pytorch.org/blog (2.9, 2.10, 2.11).
+Use this template when drafting a release blog. It mirrors the
+structure of <https://pytorch.org/blog/pytorch-2-13-release-blog/>.
+
+**Verify against the latest published post before drafting.** The
+format drifts between releases; this file records it as of 2.13.
 
 ## Template
 
 ```markdown
-# PyTorch <VERSION> Release Blog
-
 We are excited to announce the release of PyTorch® <VERSION>
 ([release notes](https://github.com/pytorch/pytorch/releases/tag/v<VERSION>.0))!
-This release features <N> commits from <M> contributors since PyTorch
-<PREV_VERSION>.
 
-## Highlights
+The PyTorch <VERSION> release features the following changes:
 
-- <Feature 1 — one line>
-- <Feature 2 — one line>
-- <Feature 3 — one line>
+- **<Headline feature>,** <one clause on what it does or how much faster>
+- **<Headline feature>,** <...>
 - ...
+- **Broader platform support**: <ROCm / Arm / XPU one-liners>
 
-Along with <VERSION>, we are also releasing updates to the PyTorch
-domain libraries. See the blog posts for [TorchAudio](#), [TorchVision](#),
-and [ExecuTorch](#).
+This release is composed of <N> commits from <M> contributors since
+PyTorch <PREV>. We want to sincerely thank our dedicated community for
+your contributions. As always, we encourage you to try these out and
+report any issues as we improve <VERSION>. More information about how
+to get started with the PyTorch 2-series can be found at our
+[Getting Started](https://pytorch.org/get-started/locally/) page.
 
----
+Have questions? Join us on <DATE> for a live Q&A with panelists
+<NAMES> and moderator <NAME>. We will provide a brief overview of the
+release and answer your questions live. [Register today.](<URL>)
 
-## Beta Features
+Throughout the 2.x series, PyTorch has been evolving from a
+research-first framework into a unified, hardware-agnostic platform for
+production training and inference at scale. [PyTorch <N-2>](<URL>)
+<what it added>. [PyTorch <N-1>](<URL>) <what it added>.
 
-### [Beta] <Feature name> — <component>
-
-<1-3 sentences describing what it does, who should care, and what
-changed vs. the previous release.>
-
-See [#<PR>](https://github.com/pytorch/pytorch/pull/<PR>) and the
-[documentation](<link>).
-
-### [Beta] <Feature name> — <component>
-...
-
----
-
-## Prototype Features
-
-### [Prototype] <Feature name> — <component>
-<description>
-
-### [Prototype] <Feature name> — <component>
-...
-
----
+PyTorch <VERSION> <one paragraph on how this release extends those
+threads>.
 
 ## Performance Improvements
 
-### <component> — <short title>
-<description, with any benchmark numbers lifted directly from the PR>
+### <Entry title>
 
----
+<Paragraph 1: the problem with the status quo.>
+
+<Paragraph 2: what changed, and what it means for the user.>
+
+API Unstable
+
+(PR [#<PR>](https://github.com/pytorch/pytorch/pull/<PR>) by <Name>, <Company>)
+
+## Core Features
+
+### <Entry title>
+...
+
+## Distributed Training
+
+### <Entry title>
+...
+
+## Compilation and Export
+
+### <Entry title>
+...
+
+## Platform Features and Updates
+
+### CUDA
+
+#### <Entry title>
+...
+
+### ROCm
+
+#### <Entry title>
+...
+
+### Arm
+
+#### <Entry title>
+...
+
+### XPU (Intel GPUs)
+
+#### <Entry title>
+...
+
+### C++ ABI
+
+#### <Entry title>
+...
+
+## Profiling and Debugging
+
+### <Entry title>
+...
 
 ## Deprecations and Backwards-Incompatible Changes
 
-- <Change + migration path>. See [#<PR>](...).
-
----
+- **<Change>.** <What to do instead.> See [#<PR>](...).
 
 ## Non-Feature Updates
 
-- **CUDA default**: <old> → <new>
-- **Python support**: <range>
-- **Release cadence**: <note if it changed>
+- **Python support**: <changes>. See [#<PR>](...).
+- **CUDA**: <default build, versions added/removed>. See [#<PR>](...).
+- **Triton**: pin advanced to <version>. See [#<PR>](...).
+- **oneDNN**: submodule upgraded to <version>. See [#<PR>](...).
 ```
 
-## Example (filled in, abbreviated — based on the 2.11 blog)
+## Worked example (from the 2.13 blog)
+
+Note the shape of an entry: problem first, then the fix, then the
+designation on its own line, then attribution.
 
 ```markdown
-# PyTorch 2.11 Release Blog
+### Deterministic Backward for FlexAttention Flash Backend
 
-We are excited to announce the release of PyTorch® 2.11
-([release notes](https://github.com/pytorch/pytorch/releases/tag/v2.11.0))!
-This release features 2,723 commits from 432 contributors since PyTorch 2.10.
+This improvement focuses on correctness and debugging for the existing
+CUDA implementation of FlexAttention by making gradient computation
+reproducible. By default, the FlexAttention flash backend uses atomic
+operations in the backward pass for dQ accumulation, which introduces
+non-determinism — repeated runs on the same input can produce slightly
+different gradients. This makes debugging, regression testing, and
+reproducible research difficult.
 
-## Highlights
+The new deterministic backward path (compute_dq_write_order) replaces
+atomics with a pre-computed write ordering that guarantees bit-for-bit
+reproducible gradients without meaningful performance penalty. The
+measured end-to-end overhead on create_block_mask is well under 1% at
+longer sequence lengths (e.g., +0.2% at S=32768), making determinism
+effectively free for most production workloads. Users can opt in via
+the existing torch.use_deterministic_algorithms(True) setting with no
+additional code changes.
 
-- Differentiable collectives enable backprop through distributed ops.
-- FlexAttention gets a FlashAttention-4 backend on Hopper/Blackwell
-  with 1.2×-3.2× speedups over Triton.
-- MPS adds async error reporting and new distributions.
-- RNN/LSTM export to GPU via `torch.export`.
-- ROCm gains device-side asserts and TopK wins.
-- XPU adds CUDA-graph-style capture/replay.
-- FP16 half-precision GEMM on CPU via OpenBLAS.
-- CUDA 13 is now the default build; TorchScript is deprecated.
+API Unstable
 
-## API-Unstable Features
-
-### [API-Unstable] Differentiable Collectives for Distributed Training
-
-Collective operations (all_reduce, all_gather, reduce_scatter) now
-support backpropagation, enabling new distributed-training research
-patterns that previously required manual gradient plumbing.
-
-See [#<TODO>] and the [distributed docs](...).
-
-### [API-Unstable] FlexAttention with FlashAttention-4 Backend
-
-FlexAttention now targets FlashAttention-4 on Hopper and Blackwell GPUs,
-with auto-generated CuTeDSL score/mask functions. Reported speedups are
-1.2×-3.2× over the Triton backend.
-
-...
-
-## Non-Feature Updates
-
-- **CUDA default**: CUDA 12.x → CUDA 13 (x86_64 and ARM). CPU-only and
-  CUDA 12.8 builds remain available.
-- **TorchScript**: deprecated since 2.10 — migrate to `torch.export` or
-  ExecuTorch.
-- **Release cadence**: moving to one release every 2 months in 2026.
+(PR [#174813](https://github.com/pytorch/pytorch/pull/174813) by Driss Guessous, Meta)
 ```
 
-## Stability tags — how to pick
+And a highlight bullet, for tone:
 
-| Tag                | When to use                                                                  |
-|--------------------|------------------------------------------------------------------------------|
-| `[Stable]`         | API is public, documented, covered by BC policy. Rarely tagged explicitly.   |
-| `[Beta]`           | Public API, usable in production, minor signature changes still possible.    |
-| `[Prototype]`      | Public API, but the team reserves the right to remove or redesign it.        |
-| `[API-Unstable]`   | Equivalent to Prototype in recent (2.9+) blogs — use this for consistency.   |
+```markdown
+- **FlexAttention lands on Apple Silicon (MPS),** with up to ~12x
+  speedup over SDPA on sparse patterns, and gains a deterministic
+  backward path on CUDA for reproducible gradient computation
+```
 
-When in doubt, match the tag the PR author used in the PR body. If the
-PR body has no tag, default to `[Prototype]` for new features and flag it
-for the release manager.
+## Designations — how to pick
 
-## Component names — canonical list
+| Designation      | When to use                                                                   |
+|------------------|-------------------------------------------------------------------------------|
+| `API Unstable`   | The default for anything new. Placed on its own line before the attribution.   |
+| *(omitted)*      | Long-standing stable surfaces. When unsure, omit and add a `TODO`.             |
 
-Use these exactly when they apply (matches recent blog posts):
+**Stable, Beta and Prototype are retired.** The 2.13 post's own
+changelog reads: *"Removed two instances of prototype which is a
+designation that we no longer use."*
 
-- Dynamo / torch.compile
-- Inductor
-- Distributed
-- Export / AOTInductor
-- Quantization
-- Profiler
-- ONNX
-- NN / Frontend
-- MPS
-- ROCm
-- XPU
-- CPU / Arm
-- CUDA
-- libtorch / C++ ABI
-- Release Engineering
+Do not render designations as heading prefixes (`### [Beta] Foo`) —
+they are body text on a line of their own.
+
+## Section names — canonical list
+
+Top-level sections, in the order 2.13 used them:
+
+1. Performance Improvements
+2. Core Features
+3. Distributed Training
+4. Compilation and Export
+5. Platform Features and Updates
+6. Profiling and Debugging
+7. Deprecations and Backwards-Incompatible Changes
+8. Non-Feature Updates
+
+Backend subsections under Platform Features and Updates: CUDA, ROCm,
+Arm, XPU (Intel GPUs), C++ ABI. Use `###` for the backend and `####`
+for entries beneath it.
+
+Placement notes worth remembering:
+
+- A large backend rewrite goes under **Performance Improvements**, not
+  its platform section. 2.13 filed "Large MPS Op Migration to Native
+  Metal" there.
+- A backend-specific compiler feature goes under its **platform**, not
+  Compilation and Export. 2.13 filed the CuTeDSL Inductor backend
+  under CUDA.
+- Release-engineering items that ship a feature (e.g. Python 3.15
+  wheels) can be a **Core Features** entry; pure version bumps belong
+  in Non-Feature Updates.
 
 ## Things to avoid
 
-- **Don't invent speedup numbers.** Only cite numbers that appear in the
-  PR body or on a linked dashboard.
+- **Don't use retired designations.** No Stable, Beta or Prototype.
+- **Don't put designations in headings.** They are body text.
+- **Don't skip attribution.** Every entry ends with `(PR #NNN by Name,
+  Company)`. Worksheets have no author data, so fetch it from the API
+  and leave a TODO to convert handles to names.
+- **Don't invent speedup numbers.** Only cite numbers that appear in
+  the PR body or on a linked dashboard. If a number comes from a PR
+  title, say so.
 - **Don't list ghstack sub-PRs.** Collapse a stack to one entry.
 - **Don't include reverts.** If `#A` was reverted by `#B` before the
-  branch cut, neither belongs in the blog.
-- **Don't include internal refactors.** If a PR only moves code around
-  without changing a user-visible API or perf number, skip it.
+  branch cut, neither belongs in the blog. Check the release branch
+  for reverts too, not just main.
 - **Don't write commit-style descriptions.** "Fix segfault in foo when
-  bar" belongs in release notes, not the blog.
+  bar" belongs in release notes, not the blog. Lead with the problem
+  the reader has.
+- **Don't infer the support matrix.** Read CUDA, ROCm and Python
+  versions off `generate_binary_build_matrix.py` on both release
+  branches and diff them.


### PR DESCRIPTION
Both skills described a stability taxonomy PyTorch no longer uses, and a document structure the published blogs do not follow. Drafting the 2.14 blog surfaced the gaps, so this refreshes them against [the 2.13 post](https://pytorch.org/blog/pytorch-2-13-release-blog/) and [the 2.13 call-for-features](https://dev-discuss.pytorch.org/t/reminder-call-for-features-pytorch-2-13/3405).

## `release-blog-features`

**Designations.** The skill asked for `[Stable]`, `[Beta]`, `[Prototype]` or `[API-Unstable]` heading prefixes. The published blog uses exactly one designation, `API Unstable`, on its own line after an entry's prose and before the PR attribution. The 2.13 post carries its own changelog note: *"Removed two instances of prototype which is a designation that we no longer use."*

**Structure.** The template had `## Beta Features` / `## Prototype Features` sections. The real blog groups by topic: Performance Improvements, Core Features, Distributed Training, Compilation and Export, Platform Features and Updates (with `### CUDA` / `ROCm` / `Arm` / `XPU` / `C++ ABI` and `####` entries beneath), Profiling and Debugging, then Deprecations and Non-Feature Updates. Also records two placement rules that are not obvious: a large backend rewrite goes under Performance Improvements (2.13 filed the MPS Metal migration there, not under MPS), and a backend-specific compiler feature goes under its platform (2.13 filed the CuTeDSL Inductor backend under CUDA).

**Attribution.** Not mentioned at all previously. Every entry ends with `(PR #NNN by Name, Company)`. The worksheets carry no author metadata, so the skill now shows how to fetch it from the REST API and says to leave a TODO converting handles to real names rather than guessing someone's employer.

**Header.** Adds the full opening shape: announcement line, bold-lead-in highlight bullets, the commits/contributors paragraph with thanks and the Getting Started link, a live Q&A paragraph, and a narrative placing the release against the previous two.

**Entry voice.** Published entries lead with the problem, then the fix, in two or three paragraphs, and explicitly thread releases together. Added with a good/bad example.

**Worksheet reality.** Step 2 assumed `done/` worksheets with PRs sorted under `### new features`. Mid-cycle that is usually false: for 2.14, 46 of 47 worksheets were still in `todo/`, with 1,202 PRs under `### Untopiced` and 11 under `### new features`. The skill now says to draw from `Untopiced`, skip `result_skip.md` and `not user facing`, filter typo fixes early, and state in the draft which worksheets were untriaged so the output is not mistaken for a complete scan. Also corrects the directory to the full `X.Y.Z` form.

**Support matrix.** New step: read CUDA/ROCm/Python versions off `generate_binary_build_matrix.py` on both release branches and diff them, rather than carrying numbers over from the last blog. Flags the built-but-not-advertised case, which 2.14 hit with CUDA 13.4.

## `feature-submission-reminder`

- Asks feature owners for **API Stable / API Unstable** instead of Stable / Beta / Prototype.
- Adds Discourse paste rules, since the release manager pastes this by hand: title outside the body (Discourse has its own title field, so a body H1 duplicates it), inline links to avoid oneboxing, and backticked identifiers so `_set_pg_timeout` does not render as italics.
- Notes the post ships *after* the branch cut in practice — the 2.13 reminder went out 24 June with M3 in the week of 8 June — so the draft must say which milestones are complete and that classifications land at M4, or a call for features reads as already too late.
- Replaces the hardcoded "MPS, Quantization, CPU/Arm" under-sampled list with a recount from the worksheets. For 2.14 the thin areas were Quantization, ONNX, Export and CPU, while MPS was the single largest pool at 82 candidates.
- Adds the 2.13 post as the primary exemplar and says to fetch the most recent one first.

## Test plan

No code, documentation only. Both skills were exercised end to end while producing the 2.14 blog draft and call-for-features post; the corrections above are what that surfaced. Reviewed the rendered Markdown for both files.
